### PR TITLE
Add a variable to update the APT cache.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ Role Variables
 ```yaml
 # versions available: 0.12 | 4.x | 5.x | 6.x
 nodejs_version: 4.x
+nodejs_packages_update_cache: no
 ```
+
+* `nodejs_packages_update_cache: Defines if the APT cache should be updated for
+  installing dependencies. Defaults to `no`.
+
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # versions available: 0.12 | 4.x | 5.x | 6.x
 nodejs_version: 6.x
+nodejs_packages_update_cache: no

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,3 +21,4 @@ dependencies:
   packages:
   - apt-transport-https
   - python-pycurl
+  packages_update_cache: "{{ nodejs_packages_update_cache }}"


### PR DESCRIPTION
If ran on a machine with an empty APT cache (on a clean VM or
container), the installation of the packages fails because there is no
metadata to know that the dependencies `apt-transport-https` and
`python-pycurl` are available on the repositories.

For this reason, I've added the `nodejs_update_cache` variable, which
wraps around the `packages_update_cache` variable from the
SimpliField.packages role.