### PR TITLE
Add license text of BSD 3-clause

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2017, Sebastien Elet
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ Example Playbook
 License
 -------
 
-BSD
+[BSD 3-clause](https://choosealicense.com/licenses/bsd-3-clause/)


### PR DESCRIPTION
BSD actually doesn't refer to a single license but to a family of similar licenses (see https://en.wikipedia.org/wiki/BSD_licenses ). Thus it should be made concrete which BSD license is meant. Since the [Wikipedia article](https://en.wikipedia.org/wiki/BSD_licenses) states "Today, the typical BSD license is the 3-clause version" I would choose this one. By linking https://choosealicense.com/licenses/bsd-3-clause/ in `README.md` it's easier to understand how this software can be forked.

By adding the license text under `LICENSE` github should be able to recognize the license automatically and show it to other users. See https://github.com/kulla/mfnf-lua-scripts with the [GPL-3.0](https://github.com/kulla/mfnf-lua-scripts/blob/master/LICENSE) link in the upper right corner.