### PR TITLE
Update key url for nodejs repository

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: add nodejs GPG key into apt
   apt_key:
-    url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
     id: "68576280"
     state: present
   tags:


### PR DESCRIPTION
The site https://github.com/nodesource/distributions#debmanual mentions the URL https://deb.nodesource.com/gpgkey/nodesource.gpg.key for the key of the repository (see second step). Thus, I guess, this URL will be updated and also work in the future (in case they will switch it).