### PR TITLE
Use "update_cache" of module "apt_repository"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,14 +11,7 @@
   apt_repository:
     repo: "deb https://deb.nodesource.com/node_{{nodejs_version}} {{ansible_distribution_release}} main"
     state: present
-  register: nodejs_repo_added
-  tags:
-  - nodejs
-
-- name: apt update cache
-  apt:
     update_cache: yes
-  when: nodejs_repo_added.changed
   tags:
   - nodejs
 


### PR DESCRIPTION
The module [`apt_repository`](http://docs.ansible.com/ansible/latest/apt_repository_module.html) has the parameter [`update_cache`](http://docs.ansible.com/ansible/latest/apt_repository_module.html#options) which can be used to automatically update the apt cache.